### PR TITLE
added inline css position for slice2 element

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -63,7 +63,7 @@
 	padding: 200px 200px 0px 200px;
 }
 
-.sl-slide-horizontal .sl-content-slice:nth-child(2) {
+.sl-slide-horizontal .sl-content-slice:nth-of-type(2) {
 	top: 50%;
 	padding: 0px 200px 200px 200px;
 }
@@ -86,7 +86,7 @@
 	padding: 200px 0px 200px 200px;
 }
 
-.sl-slide-vertical .sl-content-slice:nth-child(2) {
+.sl-slide-vertical .sl-content-slice:nth-of-type(2) {
 	left: 50%;
 	padding: 200px 200px 200px 0px;
 }


### PR DESCRIPTION
quick hack for safari on iphone with ios8

| before | after |
| --- | --- |
| ![slitslider-before-o](https://cloud.githubusercontent.com/assets/2650264/5194459/9a539fdc-750d-11e4-9c51-8c97758e6a32.png) | ![slitslider-after-o](https://cloud.githubusercontent.com/assets/2650264/5194460/9cfb974e-750d-11e4-84e2-aafd491ccf8c.png) |
