### PR TITLE
Fix the Pause functionality

### DIFF
--- a/js/jquery.slitslider.js
+++ b/js/jquery.slitslider.js
@@ -588,7 +588,7 @@
 		// public method: pauses the slideshow
 		pause : function() {
 
-			if( this.isPlaying ) {
+			if( this.isPlaying || this.options.autoplay) {
 
 				this._stopSlideshow();
 


### PR DESCRIPTION
Currently the pause only works if an animation is already going on. One would usually use the pause function to stop the slider from continuing to autoplay.
